### PR TITLE
Fix typo in index.html

### DIFF
--- a/sarasa/index.html
+++ b/sarasa/index.html
@@ -116,7 +116,7 @@ pre code {
 <header>
 <h1 id="sarasa-gothic-mono">Sarasa Gothic Mono</h1>
 <p><em>a.k.a.</em>&emsp;更纱黑体<wbr>&emsp;更紗黑體<wbr>&emsp;更紗ゴシック<wbr>&emsp;사라사고딕</p>
-<p class="center stars"><wbr><em>Rockstar of progamming typography</em><wbr></p>
+<p class="center stars"><wbr><em>Rockstar of programming typography</em><wbr></p>
 	<p class="center teal">fully fledged monospace superfamily designed for coding</p>
 <!--
 	(include why up front)


### PR DESCRIPTION
Fix a typo in heading saying `progamming` to `programming`.