### PR TITLE
create recipe filter plugin for repeatable layout indexable by lunr

### DIFF
--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -22,6 +22,9 @@ layout: table_wrappers
       {% include components/breadcrumbs.html %}
       <div id="main-content" class="main-content">
         <main itemscope itemtype="http://schema.org/Recipe">
+          {% if site.heading_anchors != false %}
+            {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
+          {% endif %}
             <p class="invisible" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
               <span itemprop="ratingValue">5</span>
               <span itemprop="reviewCount">1</span>
@@ -30,79 +33,6 @@ layout: table_wrappers
             {% include components/children_nav.html %}
           {% endif %}
           
-          <h2 id="{{ page.title | slugify }}" itemprop="name"> 
-            <a href="#{{ page.title | slugify }}" class="anchor-heading" aria-labelledby="{{ page.title | slugify }}"><svg viewBox="0 0 16 16" aria-hidden="true"><use xlink:href="#svg-link"></use></svg></a> 
-            {{ page.title }}
-          </h2>
-
-          <img src="{{ page.image }}" alt="{{ page.title }}" itemprop="image" class="recipe-image">
-
-          {% if page.prepmins or page.cookmins %}
-            <dl class="dl-horizontal">
-              {% if page.prepmins %}
-              <dt>Preparation time</dt><dd>{{ page.prepmins }} min{% if page.prepmins != 1 %}s{% endif %}<span itemprop="prepTime" class="invisible">PT{{ page.prepmins }}M</span></dd>
-              {% endif %}
-              {% if page.cookmins %}<dt>Cooking time</dt><dd>{{ page.cookmins }} min{% if page.cookmins != 1 %}s{% endif %}<span itemprop="cookTime" class="invisible">PT{{ page.cookmins }}M</span></dd>
-              {% endif %}
-              {% if page.yield %}<dt>Yield</dt><dd>{{ page.yield }} serving{% if page.yield != 1 %}s{% endif %} <span itemprop="recipeYield" class="invisible">{{ page.yield }}</span></dd>
-              {% endif %}
-            </dl>
-          {% endif %}
-          
-          <h3 id="ingredients"> <a href="#ingredients" class="anchor-heading" aria-labelledby="ingredients"><svg viewBox="0 0 16 16" aria-hidden="true"><use xlink:href="#svg-link"></use></svg></a> Ingredients </h3>
-
-          <ul itemprop="recipeIngredients">
-            {% for ingredient in page.ingredients %} 
-              <li itemprop="recipeIngredient">{{ ingredient }}</li>
-            {% endfor %}
-          </ul>
-
-          <h3 id="instructions"> <a href="#instructions" class="anchor-heading" aria-labelledby="instructions"><svg viewBox="0 0 16 16" aria-hidden="true"><use xlink:href="#svg-link"></use></svg></a> Instructions </h3>
-
-          <ol itemprop="recipeInstructions">
-            {% for instruction in page.instructions %} 
-            <li>{{ instruction }}</li>
-            {% endfor %}
-          </ol>
-
-          {% if site.heading_anchors != false %}
-            {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
-          {% else %}
-            {{ content }}
-          {% endif %}
-
-          {% if page.nutrition %}
-            <h3 id="nutrition-facts"> <a href="#nutrition-facts" class="anchor-heading" aria-labelledby="nutrition-facts"><svg viewBox="0 0 16 16" aria-hidden="true"><use xlink:href="#svg-link"></use></svg></a> Nutrition Facts </h3>
-
-            <p><em>in grams per serving</em></p>
-            <dl itemprop="nutrition" itemscope itemtype="https://schema.org/NutritionInformation">
-              <dt>Calories</dt> <dd itemprop="calories">{{ page.nutrition.calories }}</dd>
-              <dt>Fat</dt> <dd itemprop="fatContent">{{ page.nutrition.fatContent }}</dd>
-              <dt>Carbohydrates</dt> <dd itemprop="carbohydrateContent">{{ page.nutrition.carbohydrateContent }}</dd>
-              <dt>Protein</dt> <dd itemprop="proteinContent">{{ page.nutrition.proteinContent }}</dd>
-            </dl>
-
-            <p class="invisible" itemprop="description">{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}</p>
-
-            <div itemscope itemprop="author" itemtype="http://schema.org/Person" class="invisible">
-              <span itemprop="name">{{ site.title }}</span>
-            </div>
-
-            <dl>
-              {% if page.cuisine %}
-              <dt>cuisine</dt> <dd itemprop="recipeCuisine">{{ page.cuisine }}</dd>
-              {% endif %}
-              {% if page.diet %}
-              <dt>diet</dt> <dd itemprop="recipeDiet">{{ page.diet }}</dd>
-              {% endif %}
-              {% if page.category %}
-              <dt>category</dt> <dd itemprop="recipeCategory">{{ page.category }}</dd>
-              {% endif %}
-              {% if page.keywords %}
-              <dt>keywords</dt> <dd itemprop="keywords">{{ page.keywords | join: ', ' }}</dd>
-              {% endif %}
-            </dl>
-          {% endif %}
         </main>
         {% include components/footer.html %}
       </div>

--- a/_plugins/recipe_tag.rb
+++ b/_plugins/recipe_tag.rb
@@ -1,0 +1,65 @@
+module Jekyll
+  class RenderRecipeTag < Liquid::Tag
+    def render(context)
+      page = context['page']
+      site = context['site']
+      content = context['content']
+
+      # You can access any page variable here
+      title = page['title']
+      image = page['image']
+      prepmins = page['prepmins']
+      cookmins = page['cookmins']
+      recipe_yield = page['yield']
+      ingredients = page['ingredients'] || []
+      instructions = page['instructions'] || []
+      nutrition = page['nutrition'] || {}
+
+      # You can manually build the HTML string
+      output = <<~HTML
+        <h2 id="#{title.downcase.strip.gsub(' ', '-')}" itemprop="name">
+          <a href="##{title.downcase.strip.gsub(' ', '-')}" class="anchor-heading" aria-labelledby="#{title.downcase.strip.gsub(' ', '-')}"><svg viewBox="0 0 16 16" aria-hidden="true"><use xlink:href="#svg-link"></use></svg></a>
+          #{title}
+        </h2>
+        <img src="#{image}" alt="#{title}" itemprop="image" class="recipe-image">
+      HTML
+
+      if prepmins || cookmins || recipe_yield
+        output << "<dl class=\"dl-horizontal\">"
+        output << "<dt>Preparation time</dt><dd>#{prepmins} min#{'s' if prepmins != 1}<span itemprop=\"prepTime\" class=\"invisible\">PT#{prepmins}M</span></dd>" if prepmins
+        output << "<dt>Cooking time</dt><dd>#{cookmins} min#{'s' if cookmins != 1}<span itemprop=\"cookTime\" class=\"invisible\">PT#{cookmins}M</span></dd>" if cookmins
+        output << "<dt>Yield</dt><dd>#{recipe_yield} serving#{'s' if recipe_yield != 1} <span itemprop=\"recipeYield\" class=\"invisible\">#{recipe_yield}</span></dd>" if recipe_yield
+        output << "</dl>"
+      end
+
+      output << "<h3 id=\"ingredients\"><a href=\"#ingredients\" class=\"anchor-heading\" aria-labelledby=\"ingredients\"><svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg></a> Ingredients</h3>"
+      output << "<ul itemprop=\"recipeIngredients\">"
+      ingredients.each do |ingredient|
+        output << "<li itemprop=\"recipeIngredient\">#{ingredient}</li>"
+      end
+      output << "</ul>"
+
+      output << "<h3 id=\"instructions\"><a href=\"#instructions\" class=\"anchor-heading\" aria-labelledby=\"instructions\"><svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg></a> Instructions</h3>"
+      output << "<ol itemprop=\"recipeInstructions\">"
+      instructions.each do |step|
+        output << "<li>#{step}</li>"
+      end
+      output << "</ol>"
+
+      if nutrition.any?
+        output << "<h3 id=\"nutrition-facts\"><a href=\"#nutrition-facts\" class=\"anchor-heading\" aria-labelledby=\"nutrition-facts\"><svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg></a> Nutrition Facts</h3>"
+        output << "<p><em>in grams per serving</em></p>"
+        output << "<dl itemprop=\"nutrition\" itemscope itemtype=\"https://schema.org/NutritionInformation\">"
+        output << "<dt>Calories</dt><dd itemprop=\"calories\">#{nutrition['calories']}</dd>"
+        output << "<dt>Fat</dt><dd itemprop=\"fatContent\">#{nutrition['fatContent']}</dd>"
+        output << "<dt>Carbohydrates</dt><dd itemprop=\"carbohydrateContent\">#{nutrition['carbohydrateContent']}</dd>"
+        output << "<dt>Protein</dt><dd itemprop=\"proteinContent\">#{nutrition['proteinContent']}</dd>"
+        output << "</dl>"
+      end
+
+      output
+    end
+  end
+end
+
+Liquid::Template.register_tag('render_recipe', Jekyll::RenderRecipeTag)

--- a/blog/food/recipes/cheesy-peas.md
+++ b/blog/food/recipes/cheesy-peas.md
@@ -48,6 +48,8 @@ keywords: pea, protein, cashew, cheese, nachos
 
 ![image](https://github.com/user-attachments/assets/0151f588-f623-43e5-807b-f02945034ff3){:itemprop="image" .invisible}
 
+{% render_recipe %}
+
 The flavorings should make the peas fresh yet cheesy.
 
 ### More Cheese!

--- a/blog/food/recipes/natto-nacho-cheese.md
+++ b/blog/food/recipes/natto-nacho-cheese.md
@@ -49,6 +49,8 @@ keywords: natto, cashew, cheese, nachos
 
 ![image](https://github.com/user-attachments/assets/25ed8af1-600b-44f8-949f-1a5fcfb311e3){: style="float: right; max-width: 50%; border-radius: .33rem;margin-left: 1rem;" :itemprop="image" .invisible}
 
+{% render_recipe %}
+
 The resulting texture and color should resemble nacho cheese.
 
 ### How does it compare to regular nacho cheese?


### PR DESCRIPTION
Layout html in the `_includes` dir is not indexable by lunr.js into `search-data.json`.

A custom plugin is used to render the same front matter yml data into markdown itself via the liquid code:

```liquid
{% render_recipe %}
```
which can now be indexed into search.

indexable html is viewable in (for example)
```path
blog/food/recipes/_site/blog/food/recipes/natto-nacho-cheese.html
```
whereas before the html that would be rendered by the `recipe.html` layout would not exist in the file.