### PR TITLE
move TOC liquid to layout to ignore search indexing

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,8 @@
+<details open markdown="block" class="toc">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>

--- a/blog/food/recipes/dairy-free-milk.md
+++ b/blog/food/recipes/dairy-free-milk.md
@@ -11,14 +11,7 @@ tags: [milk, cashew, dairy-free, soy, savory, sweet, almond, oat, fruit, juice, 
 I recently bought a soy milk maker, which is basically a stainless steel blender with a heating element. It&nbsp;has [6 pre-programmed sequences](#pre-programmed-functions). 
 Here&nbsp;are the included recipes in the manual in case I can’t find it.
 
-<details open markdown="block" class="toc">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-- TOC
-{:toc}
-</details>
+{% include toc.html %}
 
 ## Basic Formula
 

--- a/blog/gists/math.md
+++ b/blog/gists/math.md
@@ -7,14 +7,7 @@ nav_order: 6
 
 # Math & Number Manipulations
 
-<details open markdown="block" class="toc">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-- TOC
-{:toc}
-</details>
+{% include toc.html %}
 
 ## Arithmatic
 


### PR DESCRIPTION
Related to #7 but the opposite
move TOC liquid code into `_includes` to prevent indexing into `search-data.json`

to include a table of contents in a markdown file that ignores search indexing, use this includes line instead:

```liquid
{% include toc.html %}
```