### PR TITLE
persist search bar in small and mobile screens

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -353,3 +353,30 @@ div.highlighter-rouge div.highlight {
   padding: 1rem;
   border-radius: 0.33rem;
 }
+
+/* small & mobile screen search bar customizations */
+
+.search-input { 
+  background-color: inherit
+}
+.search-input-wrap {
+    box-shadow: none;
+}
+@media screen and (max-width: 49.99rem) {
+  .search {
+    position: absolute;
+    top: 0;
+    left: 9.5em;
+    right: 6.4em;
+  }
+  .side-bar + .main .main-header {
+    display: block;
+  }
+}
+
+@media screen and (max-width: 31.249rem) {
+  .search {
+    left: 7em;
+    top: -.12rem;
+  }
+}


### PR DESCRIPTION
make sure search bar is visible and accessible at all times instead of hidden in the menu

before:
<img src="https://github.com/user-attachments/assets/ad49c614-fe24-498e-9f60-fc998c8eab3b" alt="app screenshot" width="402" align=left>

after: 
<img src="https://github.com/user-attachments/assets/373ce4b2-d5cb-4133-a2ae-33c313102142" alt="app screenshot" width="402" align=left>

before:
<img src="https://github.com/user-attachments/assets/c5518795-0ffa-4dc4-93c8-2bf768c2c3fd" alt="app screenshot" width="402" align=left>

after:
<img src="https://github.com/user-attachments/assets/fd97901a-e14b-4a4b-b7dc-a80a3ff98eef" alt="app screenshot" width="402" align=left>



