### PR TITLE
Create Toggle-able bookmarklet links with Bookmarkleter

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -482,6 +482,13 @@ h3, .toc, h2 {
   margin-right: 1rem;
 }
 
+a[href^="javascript:"]::before {
+    content: "🔖 ";
+    vertical-align: sub;
+    margin-right: -.04em;
+    opacity: .75;
+}
+
 // optinoal code block language labels
 
 // [class*="language-"]::before {

--- a/blog/design/squint-test.md
+++ b/blog/design/squint-test.md
@@ -23,7 +23,12 @@ html {
 }
 ```
 
-Toggle it on/off with this bookmarklet script
+Toggle it on/off with this bookmarklet script: [squint](javascript:void%20function(){let%20a=`
+html%20{
+%20%20filter:%20blur(.36rem);
+%20%20transition:%20filter%20.09s%20ease-out;
+}
+`;const%20b=a=%3E{let%20b=document.createElement(%22style%22);b.type=%22text/css%22,b.id=%22css_injection%22,b.innerText=a,document.head.appendChild(b)},c=()=%3Edocument.getElementById(%22css_injection%22)%3Fdocument.getElementById(%22css_injection%22).remove():b(a);c()}();)
 
 ```js
 javascript: (()=>{

--- a/blog/gists/css/debugging.md
+++ b/blog/gists/css/debugging.md
@@ -21,6 +21,10 @@ nav_order: 7
 
 ### Toggle with bookmarklet
 
+[pink glass](javascript:void%20function(){let%20a=`
+%20%20*%20{ background-color:%20%23c001%20!important}
+`;const%20b=a=%3E{let%20b=document.createElement(%22style%22);b.type=%22text/css%22,b.id=%22css_injection%22,b.innerText=a,document.head.appendChild(b)},c=()=%3Edocument.getElementById(%22css_injection%22)%3Fdocument.getElementById(%22css_injection%22).remove():b(a);c()}();)
+
 ```js
 javascript: (()=>{
 

--- a/blog/gists/javascript/bookmarklets.md
+++ b/blog/gists/javascript/bookmarklets.md
@@ -26,6 +26,10 @@ however, if you declare constants or variables here you cannot re-declare them u
 
 Here is [how to use one](https://gist.github.com/picaq/24a3c6d85583373f93c12dfae43e03ec)
 
+You can also create a bookmarklet out of any js code with [Bookmarkleter](https://chriszarate.github.io/bookmarkleter/) 
+
+Bookmarklets (as blue links with 🔖) can be dragged and dropped into your bookmarks bar or clicked to invoke its behavior.
+
 ## Formatting
 
 Compared to normal javascript, a finished bookmarklet is similar to minified js with all extraneous whitespace characters removed.
@@ -46,6 +50,7 @@ Therefore, a finished bookmarklet:
 
 As a default, 1.8e+6 is 30 minutes. Use whatever value you like in ms.
 
+[30 minute countdown](javascript:void%20function(){((a=18e5)=%3E{const%20b=new%20Date(Date.now()+a).getTime(),c=setInterval(()=%3E{var%20a=Math.floor;const%20d=new%20Date().getTime(),e=b-d,f=a(e%2586400000/3600000),g=a(e%253600000/60000),h=a(e%2560000/1e3);document.title=`${0%3Cf%3Ff+%22:%22:%22%22}${g}:${h}`,0%3Ee%26%26(clearInterval(c),document.title=%22done!%22)},1e3)})()}();)
 ```js
 javascript: (()=> {
   
@@ -75,7 +80,11 @@ javascript: (()=> {
 })();
 ```
 
-### highlight selection into a link
+### highlight selection into a link aka Text Fragments
+
+it will update in the url bar as well as copy the link to your clipboard
+
+[highlink](javascript:void%20function(){const%20a=window.location.href;let%20b=encodeURI(window.getSelection()).replaceAll(%22-%22,%22%252D%22);selectedURL=a+%22%23:~:text=%22+b,console.log(selectedURL),(a=%3E{const%20b=document.createElement(%22textarea%22);document.body.appendChild(b),b.setAttribute(%22id%22,%22temporary_input_clipboard%22),document.getElementById(%22temporary_input_clipboard%22).value=a,b.select(),document.execCommand(%22copy%22),document.body.removeChild(b)})(selectedURL),window.location.href=selectedURL}();)
 
 ```js
 javascript: (()=>{
@@ -190,6 +199,8 @@ javascript: (()=>{location.reload()})();
 ```
 
 ### edit content
+
+[edit](javascript:void%20function(){let%20a=document.querySelector(%22body%22);a.contentEditable=%22true%22!==a.contentEditable}();)
 
 ```js
 javascript: (()=>{


### PR DESCRIPTION
All bookmarklet links can be created with markdown and automatically styled with 🔖 emoji preceding each link.

They can either be clicked to be toggled on the current page or dragged to the bookmarklet bar for later usage.

```md
[link text](javascript:somecode)
```

[Bookmarkleter](https://chriszarate.github.io/bookmarkleter/) is used to minify and encode the js into a bookmarklet. 

Its github repo is here: [chriszarate/bookmarkleter: You have JavaScript. You need a bookmarklet. This does that.](https://github.com/chriszarate/bookmarkleter) 

**Note:** To avoid Liquid syntax errors in Jekyll, all instances of `{%` must be replaced with their decoded format, usually it is `{%20` → `{% `